### PR TITLE
Update README with details about need 4 env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ The file *configuration.yml* represents a template configuration. If you are hap
 
 ## Installation
 
-Clone the repository to your target machine then build it using Maven.
+Clone the repository to your target machine. You then need to set the following environment variables
+
+- `WCRS_ADDRESS_OSPLACES_KEY`
+- `WCRS_ADDRESS_OSPLACES_URL`
+
+When you execute the service it will pick these up from [configuration.yml](configuration.yml), but the unit tests which get run during a Maven build pick them up from environment variables. So ensure they are added to prevent failing builds.
+
+Now build it using Maven
 
 ```bash
 $ mvn clean package


### PR DESCRIPTION
Whilst attempting to get integration to Travis-CI working I initially thought all config for all stages of the project came from the [configuration.yml](configuration.yml) file.

However multiple failing builds later realised that the unit tests actually pull the key and OS places URL from environment variables. So to get the Maven build to work you must have these env vars set.

This change adds details about this to the README in the **Installation** section.